### PR TITLE
Integrate GitHub Actions for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,8 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - name: Checkout
-    - uses: actions/checkout@v2
     - name: Run CI
+    - uses: actions/checkout@v2
       run: xcodebuild clean test -workspace Fractal.xcworkspace -scheme DesignSystem -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest'
       

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: CI
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout
+    - uses: actions/checkout@v2
+    - name: Run CI
+      run: xcodebuild clean test -workspace Fractal.xcworkspace -scheme DesignSystem -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest'
+      

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - name: Run CI
-    - uses: actions/checkout@v2
-      run: xcodebuild clean test -workspace Fractal.xcworkspace -scheme DesignSystem -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest'
+      - uses: actions/checkout@v2
+      - name: Run CI
+        run: xcodebuild clean test -workspace Fractal.xcworkspace -scheme DesignSystem -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest'
       

--- a/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
+++ b/DesignSystem/DesignSystem.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2256487524123D1F0081CAD5 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2256487424123D1F0081CAD5 /* main.m */; };
+		2256487C24123FA80081CAD5 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92BA38F72179829800266383 /* DesignSystem.framework */; };
+		2256487D24123FA80081CAD5 /* DesignSystem.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 92BA38F72179829800266383 /* DesignSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		723609162282AD2100300065 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 723609152282AD2100300065 /* Images.xcassets */; };
 		7244A0AA230D234F00C7EC28 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7244A0A9230D234F00C7EC28 /* Observable.swift */; };
 		728D057A2282996000B44543 /* BrandingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728D05752282996000B44543 /* BrandingManager.swift */; };
@@ -57,6 +60,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2256487924123E3A0081CAD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 92BA38EE2179829800266383 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2256485F24123D1E0081CAD5;
+			remoteInfo = DesignSystemTestHost;
+		};
+		2256487E24123FA80081CAD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 92BA38EE2179829800266383 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 92BA38F62179829800266383;
+			remoteInfo = DesignSystem;
+		};
 		92BA39022179829900266383 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 92BA38EE2179829800266383 /* Project object */;
@@ -66,8 +83,25 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		2256488024123FA80081CAD5 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				2256487D24123FA80081CAD5 /* DesignSystem.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		2256485A241233AF0081CAD5 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2256486024123D1E0081CAD5 /* FractalTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FractalTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2256487324123D1F0081CAD5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2256487424123D1F0081CAD5 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		723609152282AD2100300065 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Resources/Images.xcassets; sourceTree = SOURCE_ROOT; };
 		7244A0A9230D234F00C7EC28 /* Observable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		728D05752282996000B44543 /* BrandingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BrandingManager.swift; path = Sources/DesignSystem/BrandingManager.swift; sourceTree = SOURCE_ROOT; };
@@ -120,6 +154,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2256485D24123D1E0081CAD5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2256487C24123FA80081CAD5 /* DesignSystem.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		92BA38F32179829800266383 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -138,6 +180,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2256486124123D1F0081CAD5 /* HostApp */ = {
+			isa = PBXGroup;
+			children = (
+				2256487324123D1F0081CAD5 /* Info.plist */,
+				2256487424123D1F0081CAD5 /* main.m */,
+			);
+			path = HostApp;
+			sourceTree = "<group>";
+		};
+		2256487B24123FA80081CAD5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		7244A0A8230D233D00C7EC28 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
@@ -279,6 +337,7 @@
 				920962EE2271518D00FC8E6F /* SectionSystem */,
 				92BA39042179829900266383 /* DesignSystemTests */,
 				92BA38F82179829800266383 /* Products */,
+				2256487B24123FA80081CAD5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -287,6 +346,7 @@
 			children = (
 				92BA38F72179829800266383 /* DesignSystem.framework */,
 				92BA39002179829900266383 /* DesignSystemTests.xctest */,
+				2256486024123D1E0081CAD5 /* FractalTestApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -294,6 +354,7 @@
 		92BA39042179829900266383 /* DesignSystemTests */ = {
 			isa = PBXGroup;
 			children = (
+				2256486124123D1F0081CAD5 /* HostApp */,
 				92BA39052179829900266383 /* DesignSystemTests.swift */,
 				92BA39072179829900266383 /* Info.plist */,
 			);
@@ -314,6 +375,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		2256485F24123D1E0081CAD5 /* DesignSystemTestHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2256487624123D1F0081CAD5 /* Build configuration list for PBXNativeTarget "DesignSystemTestHost" */;
+			buildPhases = (
+				2256485C24123D1E0081CAD5 /* Sources */,
+				2256485D24123D1E0081CAD5 /* Frameworks */,
+				2256488024123FA80081CAD5 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2256487F24123FA80081CAD5 /* PBXTargetDependency */,
+			);
+			name = DesignSystemTestHost;
+			productName = DesignSystemTestHost;
+			productReference = 2256486024123D1E0081CAD5 /* FractalTestApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		92BA38F62179829800266383 /* DesignSystem */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 92BA390B2179829900266383 /* Build configuration list for PBXNativeTarget "DesignSystem" */;
@@ -344,6 +423,7 @@
 			);
 			dependencies = (
 				92BA39032179829900266383 /* PBXTargetDependency */,
+				2256487A24123E3A0081CAD5 /* PBXTargetDependency */,
 			);
 			name = DesignSystemTests;
 			productName = DesignSystemTests;
@@ -360,12 +440,16 @@
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = mercari;
 				TargetAttributes = {
+					2256485F24123D1E0081CAD5 = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
 					92BA38F62179829800266383 = {
 						CreatedOnToolsVersion = 9.4.1;
 						LastSwiftMigration = 1020;
 					};
 					92BA38FF2179829900266383 = {
 						CreatedOnToolsVersion = 9.4.1;
+						TestTargetID = 2256485F24123D1E0081CAD5;
 					};
 				};
 			};
@@ -384,6 +468,7 @@
 			targets = (
 				92BA38F62179829800266383 /* DesignSystem */,
 				92BA38FF2179829900266383 /* DesignSystemTests */,
+				2256485F24123D1E0081CAD5 /* DesignSystemTestHost */,
 			);
 		};
 /* End PBXProject section */
@@ -407,6 +492,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2256485C24123D1E0081CAD5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2256487524123D1F0081CAD5 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		92BA38F22179829800266383 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -468,6 +561,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2256487A24123E3A0081CAD5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2256485F24123D1E0081CAD5 /* DesignSystemTestHost */;
+			targetProxy = 2256487924123E3A0081CAD5 /* PBXContainerItemProxy */;
+		};
+		2256487F24123FA80081CAD5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 92BA38F62179829800266383 /* DesignSystem */;
+			targetProxy = 2256487E24123FA80081CAD5 /* PBXContainerItemProxy */;
+		};
 		92BA39032179829900266383 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 92BA38F62179829800266383 /* DesignSystem */;
@@ -476,6 +579,51 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		2256487724123D1F0081CAD5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_MODULES_DISABLE_PRIVATE_WARNING = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
+				INFOPLIST_FILE = DesignSystemTests/HostApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.no-data.DesignSystemTestHost";
+				PRODUCT_NAME = FractalTestApp;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		2256487824123D1F0081CAD5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CLANG_MODULES_DISABLE_PRIVATE_WARNING = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
+				INFOPLIST_FILE = DesignSystemTests/HostApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.no-data.DesignSystemTestHost";
+				PRODUCT_NAME = FractalTestApp;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
 		92BA39092179829900266383 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -660,18 +808,21 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2CCV6DZ29E;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = DesignSystemTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = mercari.DesignSystemTests;
+				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.no-data.DesignSystemTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FractalTestApp.app/FractalTestApp";
 			};
 			name = Debug;
 		};
@@ -679,24 +830,36 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2CCV6DZ29E;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = DesignSystemTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = mercari.DesignSystemTests;
+				PRODUCT_BUNDLE_IDENTIFIER = "uk.co.no-data.DesignSystemTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FractalTestApp.app/FractalTestApp";
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2256487624123D1F0081CAD5 /* Build configuration list for PBXNativeTarget "DesignSystemTestHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2256487724123D1F0081CAD5 /* Debug */,
+				2256487824123D1F0081CAD5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		92BA38F12179829800266383 /* Build configuration list for PBXProject "DesignSystem" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/DesignSystem/DesignSystem.xcodeproj/xcshareddata/xcschemes/DesignSystemTestHost.xcscheme
+++ b/DesignSystem/DesignSystem.xcodeproj/xcshareddata/xcschemes/DesignSystemTestHost.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2256485F24123D1E0081CAD5"
+               BuildableName = "FractalTestApp.app"
+               BlueprintName = "DesignSystemTestHost"
+               ReferencedContainer = "container:DesignSystem.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2256485F24123D1E0081CAD5"
+            BuildableName = "FractalTestApp.app"
+            BlueprintName = "DesignSystemTestHost"
+            ReferencedContainer = "container:DesignSystem.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2256485F24123D1E0081CAD5"
+            BuildableName = "FractalTestApp.app"
+            BlueprintName = "DesignSystemTestHost"
+            ReferencedContainer = "container:DesignSystem.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DesignSystem/DesignSystemTests/HostApp/Info.plist
+++ b/DesignSystem/DesignSystemTests/HostApp/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>LSUIElement</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/DesignSystem/DesignSystemTests/HostApp/main.m
+++ b/DesignSystem/DesignSystemTests/HostApp/main.m
@@ -1,0 +1,22 @@
+//
+//  main.m
+//  DesignSystemTestHost
+//
+//  Created by Tim Oliver on 2020/03/06.
+//  Copyright © 2020 mercari. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@property (strong, nonatomic) UIWindow *window;
+@end
+
+@implementation AppDelegate
+@end
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Fractal
 
-An iOS Design System based on Atomic Design Theory and Declarative UI
+[![Build Status](https://github.com/nodata/fractal/workflows/CI/badge.svg)](https://github.com/nodata/fractal/actions)
+
+An iOS Design System based on Atomic Design Theory and Declarative UI.
 
 ## Installation
 


### PR DESCRIPTION
Integrates GitHub Actions for basic CI and unit testing.

* Fixed iOS build mis-matches between framework and test target.
* Added a miniature host app in order to execute tests in the simulator.
* Adds a CI.yml to configure the build command.
* Added badge to README.